### PR TITLE
Handle nullable input for enums

### DIFF
--- a/lib/templates/android-kotlin/README.md
+++ b/lib/templates/android-kotlin/README.md
@@ -38,17 +38,17 @@ import io.realm.RealmObject
 class FidelityCard: RealmObject() {
 
     object Attributes {
-        const val IDENTIFIER: String = "identifier";
-        const val POINTS: String = "points";
+        const val IDENTIFIER: String = "identifier"
+        const val POINTS: String = "points"
     }
 
     object Relationships {
-        const val USER: String = "user";
+        const val USER: String = "user"
     }
 
-    private var identifier: Short = 0;
-    private var points: Integer = 0;
-    private var user: User? = null;
+    private var identifier: Short = 0
+    private var points: Integer = 0
+    private var user: User? = null
 }
 ```
 

--- a/lib/templates/android-kotlin/enum.liquid
+++ b/lib/templates/android-kotlin/enum.liquid
@@ -21,7 +21,7 @@ enum class {{ attribute.enum_type }}(val jsonValue: String) {
 
     companion object {
         @JvmStatic
-        fun get(jsonValue: String): {{ attribute.enum_type }}? {
+        fun get(jsonValue: String?): {{ attribute.enum_type }}? {
             return {{ attribute.enum_type }}.values().firstOrNull { it.jsonValue == jsonValue }
         }
     }

--- a/spec/fixtures/kotlin/enum/OptValue.kt
+++ b/spec/fixtures/kotlin/enum/OptValue.kt
@@ -11,7 +11,7 @@ enum class OptValue(val jsonValue: String) {
 
     companion object {
         @JvmStatic
-        fun get(jsonValue: String): OptValue? {
+        fun get(jsonValue: String?): OptValue? {
             return OptValue.values().firstOrNull { it.jsonValue == jsonValue }
         }
     }

--- a/spec/fixtures/kotlin/enum/Type.kt
+++ b/spec/fixtures/kotlin/enum/Type.kt
@@ -11,7 +11,7 @@ enum class Type(val jsonValue: String) {
 
     companion object {
         @JvmStatic
-        fun get(jsonValue: String): Type? {
+        fun get(jsonValue: String?): Type? {
             return Type.values().firstOrNull { it.jsonValue == jsonValue }
         }
     }

--- a/spec/fixtures/kotlin/enum_json/Type.kt
+++ b/spec/fixtures/kotlin/enum_json/Type.kt
@@ -11,7 +11,7 @@ enum class Type(val jsonValue: String) {
 
     companion object {
         @JvmStatic
-        fun get(jsonValue: String): Type? {
+        fun get(jsonValue: String?): Type? {
             return Type.values().firstOrNull { it.jsonValue == jsonValue }
         }
     }

--- a/spec/fixtures/kotlin/enum_json/Type2.kt
+++ b/spec/fixtures/kotlin/enum_json/Type2.kt
@@ -11,7 +11,7 @@ enum class Type2(val jsonValue: String) {
 
     companion object {
         @JvmStatic
-        fun get(jsonValue: String): Type2? {
+        fun get(jsonValue: String?): Type2? {
             return Type2.values().firstOrNull { it.jsonValue == jsonValue }
         }
     }

--- a/spec/fixtures/kotlin/enum_multi/TypeA.kt
+++ b/spec/fixtures/kotlin/enum_multi/TypeA.kt
@@ -11,7 +11,7 @@ enum class TypeA(val jsonValue: String) {
 
     companion object {
         @JvmStatic
-        fun get(jsonValue: String): TypeA? {
+        fun get(jsonValue: String?): TypeA? {
             return TypeA.values().firstOrNull { it.jsonValue == jsonValue }
         }
     }

--- a/spec/fixtures/kotlin/enum_multi/TypeB.kt
+++ b/spec/fixtures/kotlin/enum_multi/TypeB.kt
@@ -11,7 +11,7 @@ enum class TypeB(val jsonValue: String) {
 
     companion object {
         @JvmStatic
-        fun get(jsonValue: String): TypeB? {
+        fun get(jsonValue: String?): TypeB? {
             return TypeB.values().firstOrNull { it.jsonValue == jsonValue }
         }
     }


### PR DESCRIPTION
Basically when an enum value is optionnal, the generated code would not compile because of a null check in Kotlin. 